### PR TITLE
Add conditional for Ubuntu 18 to use python 3.6

### DIFF
--- a/templates/adjutant-wsgi.load.j2
+++ b/templates/adjutant-wsgi.load.j2
@@ -1,4 +1,8 @@
 # {{ ansible_managed }}
 
+{% if ansible_distribution_major_version == '16' %}
 LoadModule wsgi_module "/openstack/venvs/adjutant-{{ adjutant_venv_tag }}/lib/python3.5/site-packages/mod_wsgi/server/mod_wsgi-py35.cpython-35m-x86_64-linux-gnu.so"
+{% else %}
+LoadModule wsgi_module "/openstack/venvs/adjutant-{{ adjutant_venv_tag }}/lib/python3.6/site-packages/mod_wsgi/server/mod_wsgi-py36.cpython-36m-x86_64-linux-gnu.so"
+{% endif %}
 WSGIPythonHome "/openstack/venvs/adjutant-{{ adjutant_venv_tag }}"


### PR DESCRIPTION
Apache2 failed to enable modules with a2enmod because we were pointing to the incorrect python version for the venv files for Ubuntu 18. 

I was not aware of any ansible variables to discover the python version of the venv, might be a better way to do this but it works like this. 